### PR TITLE
Development

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -27,6 +27,9 @@ int inDebug;
 // Quiet Mode Flag: If set, warnings are disabled.
 int inQuiet;
 
+// Color Mode Flag: If set, output is color-formatted.
+int inColor;
+
 typedef enum {
     Structure,
     Control,

--- a/mpascal.lex
+++ b/mpascal.lex
@@ -23,7 +23,6 @@ letter          [a-zA-Z]
 identifier      {letter}({letter}|{digit}|"_")*
 integer         {digit}+
 real            {integer}("."{integer})?
-addop           [+-]
 mulop           [*]
 comment         \{[^\}]*\}
 
@@ -64,7 +63,8 @@ comment         \{[^\}]*\}
 ">"             { printToken(Operation);    return MP_RELOP_GT; }
 "<>"            { printToken(Operation);    return MP_RELOP_NE; }
 
-{addop}         { printToken(Operation);    return MP_ADDOP;    }
+"+"             { printToken(Operation);    return MP_ADDOP;    }
+"-"             { printToken(Operation);    return MP_SUBOP;    }
 
 {mulop}         { printToken(Operation);    return MP_MULOP;    } 
 (?i:DIV)        { printToken(Operation);    return MP_DIVOP;    }

--- a/mpascal.y
+++ b/mpascal.y
@@ -144,11 +144,12 @@ int yyerror(char *s) {
 ********************************************************************************
 */
 
-program : MP_PROGRAM MP_ID MP_POPEN identifierList MP_PCLOSE MP_SCOLON declarations { /* Install declarations in symbol-table */ installVarList($7); freeVarList($7); } 
+program : MP_PROGRAM MP_ID MP_POPEN identifierList { /* Ignore program parameters */ freeVarList($4); } 
+          MP_PCLOSE MP_SCOLON declarations { /* Install declarations in symbol-table */ installVarList($8); freeVarList($8); } 
           subprogramDeclarations 
           compoundStatement 
           MP_FSTOP MP_EOF 
-          { printf("ACCEPTED\n"); exit(0); }
+          { printf("ACCEPTED\n"); YYACCEPT; }
         ;
 
 identifierList  : identifier                                          { /* Insert new varType for identifier in a new varList */

--- a/mpascal.y
+++ b/mpascal.y
@@ -23,6 +23,7 @@
 /* Variables local to debug. */
 extern int inDebug;
 extern int inQuiet;
+extern int inColor;
 
 /* Variables local to lex.yy.c */
 extern int yylex();
@@ -58,7 +59,8 @@ int yyerror(char *s) {
 %token MP_ELSE
 
 // Arithmetic Operator Tokens.
-%token MP_ADDOP 
+%token MP_ADDOP
+%token MP_SUBOP 
 %token MP_MULOP 
 %token MP_DIVOP
 %token MP_MODOP
@@ -129,7 +131,7 @@ int yyerror(char *s) {
 }
 
 // Nonterminal return type rules.
-%type <num> standardType identifier statementList optionalStatements
+%type <num> standardType identifier statementList optionalStatements sign
 %type <desc> type
 %type <var> factor term simpleExpression expression variable subprogramHead
 %type <varList> expressionList identifierList parameterList arguments declarations
@@ -149,7 +151,7 @@ program : MP_PROGRAM MP_ID MP_POPEN identifierList { /* Ignore program parameter
           subprogramDeclarations 
           compoundStatement 
           MP_FSTOP MP_EOF 
-          { printf("ACCEPTED\n"); YYACCEPT; }
+          { YYACCEPT; }
         ;
 
 identifierList  : identifier                                          { /* Insert new varType for identifier in a new varList */
@@ -239,7 +241,7 @@ statementList : statement                                         { $$ = 1; }
               | statementList MP_SCOLON statement                 { $$ = $1 + 1; } 
               ;
 
-statement : variable MP_ASSIGNOP expression                       { /* Verify expression may be assigned to variable */
+statement : variable MP_ASSIGNOP expression                       { /* Verify expression may be assigned to variable.*/
                                                                     verifyAssignment($1, $3); 
                                                                   }                 
           | procedureStatement
@@ -297,9 +299,11 @@ expression  : simpleExpression                                    { $$ = $1; }
             ;
 
 simpleExpression  : term                                          { $$ = $1; }
-                  | sign term                                     { $$ = $2; }
-                  | simpleExpression MP_ADDOP term                { /* Check arithmetic expression types and attempt to resolve/fold expression */
-                                                                    $$ = resolveArithmeticOperation(MP_ADDOP, $1, $3); 
+                  | sign term                                     { /* Apply a sign to the term if constant. */
+                                                                    $$ = applySign($1, $2); 
+                                                                  }
+                  | simpleExpression sign term                    { /* Check arithmetic expression types and attempt to resolve/fold expression */
+                                                                    $$ = resolveArithmeticOperation($2, $1, $3); 
                                                                   }
                   ;
 
@@ -311,9 +315,8 @@ term  : factor                                                    { $$ = $1; }
       | term MP_MODOP factor                                      { $$ = resolveArithmeticOperation(MP_MODOP, $1, $3); }
       ;
 
-factor  : identifier                                              { /* Verify variable factor exists. Warn if uninitialized */
+factor  : identifier                                              { /* Verify variable factor exists. Initialization check is postponed until usage */
                                                                     if (existsId($1, TC_ANY)) {
-                                                                      isInitialized($1, TC_ANY);
                                                                       $$ = initVarTypeFromId($1, TC_ANY);
                                                                     } else { 
                                                                       $$ = initExprVarType(UNDEFINED, UNDEFINED, NIL); 
@@ -345,7 +348,8 @@ identifier : MP_ID                                                { /* Dedicated
                                                                     $$ = installId(yytext); 
                                                                   }
 
-sign  : MP_ADDOP
+sign  : MP_ADDOP                                                  { $$ = MP_ADDOP; }
+      | MP_SUBOP                                                  { $$ = MP_SUBOP; }
       ;
 
 
@@ -357,20 +361,39 @@ sign  : MP_ADDOP
  ********************************************************************************
  */
 
-/* Parses program argument vector for program flags */
+/* Simply usage manual */
+ #define MP_USAGE   "\nSupported Program Flags:\n \
+\t-d : Debug Mode. Outputs file while parsing.\n \
+\t-q : Quiet Mode. Surpresses all warnings.\n \
+\t-c : Color Mode. All output (and syntax) has\n \
+\t     color.\n\n"
+
+/* Parses program argument vector for program flags.
+ * Supported flags: 
+ * -c : Color Mode. Semantic Analysis output is color-formatted.
+ * -d : Debug Mode. Outputs lines as they are parsed. Useful for syntax errors.
+ * -q : Quiet Mode. Disabled all warnings.
+ */
 void parseArguments (int argc, char *argv[]) {
   char *arg;
 
   while (--argc && *(arg = *++argv) == '-') {
     switch (*++arg) {
+      case 'c':
+        inColor = 1;
+        break;
       case 'd':
         inDebug = 1; 
+        break;
+      case 'h':
+        fprintf(stdout, MP_USAGE);
         break;
       case 'q':
         inQuiet = 1;
         break;
       default:
         fprintf(stderr, "Unknown argument \"-%s\"!\n", arg);
+        fprintf(stderr, "%s", MP_USAGE);
         exit(EXIT_FAILURE);
         break;
     }

--- a/mptypes.h
+++ b/mptypes.h
@@ -19,10 +19,10 @@
 */
 
 // Represents an invalid table number index.
-#define NIL         -1    
+#define NIL             -1    
 
 // Type: Undefined.
-#define UNDEFINED    0
+#define UNDEFINED       0
 
 // Token-Type: Primitives.
 #define TT_INTEGER      1

--- a/semantics.h
+++ b/semantics.h
@@ -49,6 +49,11 @@ varType resolveArithmeticOperation (unsigned operator, varType a, varType b);
 */
 varType resolveBooleanOperation (unsigned operator, varType a, varType b);
 
+/* Applies a sign to a constant exprVarType. If not constant, the exprVarType
+ * is simply returned.
+*/
+varType applySign (unsigned operator, varType exprVarType);
+
 /* Throws a warning if token-type of variable-expression isn't integer */
 void verifyGuardExprVar (varType var);
 
@@ -64,10 +69,11 @@ void verifyGuardExprVar (varType var);
 varType initVarTypeFromId (unsigned id, unsigned tc);
 
 /* Resolves assignment of expression-variable to variable.
- * 1. If variable token-class is not scalar, an error is thrown.
- * 2. If expression-variable token-type is undefined, an error is thrown.
- * 3. Type promotion or truncation occurs in case of mismatching primitives.
- * 4. Sets the reference flag (rf) to true.
+ * 1. If variable token-class is not class scalar or vector, an error is thrown.
+ * 2. If expression-variable token-type is not primitive, an error is thrown.
+ * 3. If expression-variable has an id. Verify that variable was initialized.
+ * 4. Type promotion or truncation occurs in case of mismatching primitives.
+ * 5. Sets the reference flag (rf) to true.
  */ 
 void verifyAssignment (varType var, varType exprVar);
 


### PR DESCRIPTION
The following changes are being merged.
1. Color output is now disabled by default. Must be signaled with the `-c` flag if desired.
2. Uninitialized variable warnings do not take place in expressions. Only check is for direct assignment.
3. Semantic checker now applies signs when folding constant expressions. Should be able to detect more division-by-zero errors and so forth. 

This revision will need to be checked for memory leaks and extra scrutiny applied to the changes I made in the lexer as I did introduce a new token and make some adjustments in that department. As far as I can tell though, I haven't changed the language. Everything should work as normal.